### PR TITLE
COM-925] fix: Update foundry.toml to locate tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 src = 'contracts/src'
+test = 'contracts/test'
 out = 'contracts/out'
 libs = ['contracts/lib']
 solc-version = "0.8.17"


### PR DESCRIPTION
Updates `foundry.toml` to locate tests directory
![image](https://user-images.githubusercontent.com/14217867/216140694-02ce682a-f21c-4153-980d-769df6cf94c4.png)
