### PR TITLE
Further optimizations and Medium level bug remediated. 

### DIFF
--- a/contracts/src/Airdrop.sol
+++ b/contracts/src/Airdrop.sol
@@ -1,7 +1,6 @@
 // License: https://github.com/magna-eng/wentokens/blob/33525bd94508f0976e114bcbc6761add2a21ad06/LICENSE.md
 pragma solidity =0.8.17;
 
-import "@openzeppelin/token/ERC20/utils/SafeERC20.sol";
 
 /**
  ▄█     █▄     ▄████████ ███▄▄▄▄       ███      ▄██████▄     ▄█   ▄█▄    ▄████████ ███▄▄▄▄      ▄████████ 
@@ -22,6 +21,12 @@ import "@openzeppelin/token/ERC20/utils/SafeERC20.sol";
  * @author Magna (@MagnaTokens)
  */
 contract Airdrop {
+
+    // 0x8689d991
+    error EthNotSent(); 
+    // 0x543bf3c4 
+    error arrayLengthMismatch();
+
     /**
      *
      * @param _recipients list of recipients
@@ -33,22 +38,25 @@ contract Airdrop {
     ) external payable {
         // looop through _recipients
         assembly {
-            // store runningTotal
-            let runningTotal := 0
-            // store length of _recipients
-            let sz := _amounts.length
-            for {
-                let i := 0
-            } lt(i, sz) {
-                // increment i
-                i := add(i, 1)
-            } {
-                // store offset for _amounts[i]
-                let offset := mul(i, 0x20)
+
+            // LCFR - fix for array length bug. 
+            if iszero(eq(_recipients.length, _amounts.length)) {
+                mstore(0x00, 0x543bf3c4)
+                revert(0x1c, 0x04)
+            }
+
+            let i := 0
+            for {} 1 { i:= add(i, 1) } {
+                if eq(i, _recipients.length){ break }
+
+                let offset := shl(5, i)
+
                 // store _amounts[i]
                 let amt := calldataload(add(_amounts.offset, offset))
+
                 // store _recipients[i]
                 let recp := calldataload(add(_recipients.offset, offset))
+
                 // send _amounts[i] to _recipients[i]
                 let success := call(
                     gas(),
@@ -61,14 +69,14 @@ contract Airdrop {
                 )
                 // revert if call fails
                 if iszero(success) {
+                    returndatacopy(0x00, 0x00, returndatasize())
                     revert(0, 0)
                 }
-                // add _amounts[i] to runningTotal
-                runningTotal := add(runningTotal, amt)
             }
-            // revert if runningTotal != msg.value
-            if iszero(eq(runningTotal, callvalue())) {
-                revert(0, 0)
+
+            if gt(selfbalance(), 0) {
+                mstore(0x00, 0x8689d991)
+                revert(0x1c, 0x04)
             }
         }
     }
@@ -81,81 +89,68 @@ contract Airdrop {
      * @param _total total amount to transfer from caller
      */
     function airdropERC20(
-        IERC20 _token,
+        address _token,
         address[] calldata _recipients,
-        uint256[] calldata _amounts,
+        uint256[] calldata _amounts, 
         uint256 _total
     ) external {
-        // bytes selector for transferFrom(address,address,uint256)
-        bytes4 transferFrom = 0x23b872dd;
-        // bytes selector for transfer(address,uint256)
-        bytes4 transfer = 0xa9059cbb;
-
         assembly {
-            // store transferFrom selector
-            let transferFromData := add(0x20, mload(0x40))
-            mstore(transferFromData, transferFrom)
-            // store caller address
-            mstore(add(transferFromData, 0x04), caller())
-            // store address
-            mstore(add(transferFromData, 0x24), address())
-            // store _total
-            mstore(add(transferFromData, 0x44), _total)
-            // call transferFrom for _total
+
+            if iszero(eq(_recipients.length, _amounts.length)) {
+                mstore(0x00, 0x543bf3c4)
+                revert(0x1c, 0x04)
+            }
+
+            // store the transferFrom selector at 0x00
+            mstore(0x00, 0x23b872ddac1db17cac1db17cac1db17cac1db17cac1db17cac1db17cac1db17c)
+            // store the caller as the first parameter to transferFrom()
+            mstore(0x04, caller())
+            // store the contract address as the second parameter to transferFrom()
+            mstore(0x24, address())
+            // store the total amount to transfer as the third parameter to transferFrom()
+            mstore(0x44, _total)
+
             let successTransferFrom := call(
                 gas(),
                 _token,
                 0,
-                transferFromData,
+                0,
                 0x64,
                 0,
                 0
             )
+
             // revert if call fails
             if iszero(successTransferFrom) {
                 revert(0, 0)
             }
 
-            // store transfer selector
-            let transferData := add(0x20, mload(0x40))
-            mstore(transferData, transfer)
+            // store the transfer selector at 0x00
+            let transfer := 0xa9059cbbac1db17cac1db17cac1db17cac1db17cac1db17cac1db17cac1db17c
+            mstore(0x00, transfer)
+            // store the recipient as the first parameter to transfer()
+            let i := 0
+            for {} 1 { i:= add(i, 1) } {
+                if eq(i, _recipients.length){ break }
 
-            // store length of _recipients
-            let sz := _amounts.length
-
-            // loop through _recipients
-            for {
-                let i := 0
-            } lt(i, sz) {
-                // increment i
-                i := add(i, 1)
-            } {
                 // store offset for _amounts[i]
-                let offset := mul(i, 0x20)
-                // store _amounts[i]
-                let amt := calldataload(add(_amounts.offset, offset))
-                // store _recipients[i]
-                let recp := calldataload(add(_recipients.offset, offset))
-                // store _recipients[i] in transferData
-                mstore(
-                    add(transferData, 0x04),
-                    recp
-                )
-                // store _amounts[i] in transferData
-                mstore(
-                    add(transferData, 0x24),
-                    amt
-                )
-                // call transfer for _amounts[i] to _recipients[i]
+                // let offset := mul(i, 0x20)
+                let offset := shl(5, i)
+
+                calldatacopy(0x04, add(_recipients.offset, offset), 0x20)
+
+                calldatacopy(0x24, add(_amounts.offset, offset), 0x20)
+
                 let successTransfer := call(
                     gas(),
                     _token,
                     0,
-                    transferData,
+                    0,
                     0x44,
                     0,
                     0
                 )
+
                 // revert if call fails
                 if iszero(successTransfer) {
                     revert(0, 0)

--- a/contracts/src/AirdropComparison.sol
+++ b/contracts/src/AirdropComparison.sol
@@ -4,6 +4,23 @@ pragma solidity =0.8.17;
 import "@openzeppelin/token/ERC20/utils/SafeERC20.sol";
 
 contract AirdropComparison {
+
+    /* 
+    Summary: 
+
+    LCFR AirdropETH - 135k gas Less than WenTokens
+    LCFR AirdropERC20 - 54k gas Less than WenTokens
+
+    | Function Name                                                  | min             | avg      | median   | max      | # calls |
+    | airdropERC20                                                   | 29438864        | 29438864 | 29438864 | 29438864 | 1       |
+    | airdropERC20LCFR                                               | 29384761        | 29384761 | 29384761 | 29384761 | 1       |
+    | airdropETH                                                     | 62458757        | 62458757 | 62458757 | 62458757 | 2       |
+    | airdropETHLCFR                                                 | 62323746        | 62323746 | 62323746 | 62323746 | 1       |
+    | disperseToken                                                  | 38802181        | 38802181 | 38802181 | 38802181 | 1       |
+    */
+
+    error EthNotSent(); // 0x8689d991
+
     /**
      *
      * @param _token ERC20 token to airdrop
@@ -17,12 +34,18 @@ contract AirdropComparison {
         uint256[] calldata _amounts,
         uint256 _total
     ) external {
+        // LCFR - do this in the assembly block + add extra 28 non-zero bytes to save non-zero -> zero gas costs.
         // bytes selector for transferFrom(address,address,uint256)
         bytes4 transferFrom = 0x23b872dd;
         // bytes selector for transfer(address,uint256)
         bytes4 transfer = 0xa9059cbb;
 
         assembly {
+            // LCFR
+            // Use scratch space to store the data for the calls
+            // transferFrom calldata is 64bytes meaning can use scratch space safely.
+            // this removes uncessary add()'s and other calls for keeping track of freememptr.
+
             // store transferFrom selector
             let transferFromData := add(0x20, mload(0x40))
             mstore(transferFromData, transferFrom)
@@ -44,15 +67,22 @@ contract AirdropComparison {
             )
             // revert if call fails
             if iszero(successTransferFrom) {
+                // LCFR - add returndatacopy to bubble up the revert reason
                 revert(0, 0)
             }
 
+            // LCFR - overwrite the previous calls data instead of getting a new freemem location.
             // store transfer selector
             let transferData := add(0x20, mload(0x40))
             mstore(transferData, transfer)
 
+            // LCFR - caching outside of loop in assembly generally costs more.
             // store length of _recipients
             let sz := _amounts.length
+
+            // LCFR - reformat the loop structure to be more effecient:
+            // initialize i outside of the pre loop declaration.
+            // break if eq() inside of the loop.
 
             // loop through _recipients
             for {
@@ -62,12 +92,15 @@ contract AirdropComparison {
                 i := add(i, 1)
             } {
                 // store offset for _amounts[i]
+                // LCFR - use shl instead of mul
                 let offset := mul(i, 0x20)
                 // store _amounts[i]
                 let amt := calldataload(add(_amounts.offset, offset))
                 // store _recipients[i]
                 let recp := calldataload(add(_recipients.offset, offset))
                 // store _recipients[i] in transferData
+
+                // LCFR - use calldatacopy to write directly to memory offsets and remove uneeded add()s
                 mstore(
                     add(transferData, 0x04),
                     recp
@@ -87,6 +120,190 @@ contract AirdropComparison {
                     0,
                     0
                 )
+                // revert if call fails
+                if iszero(successTransfer) {
+                    // use returndatacopy to bubble up revert reason
+                    revert(0, 0)
+                }  
+            }
+        }
+    }
+
+    function airdropETH(
+        address[] calldata _recipients,
+        uint256[] calldata _amounts
+    ) external payable {
+        // looop through _recipients
+        assembly {
+            // store runningTotal
+            // LCFR - not quite sure why this is needed - validate all ETH sent?
+            let runningTotal := 0
+            
+            // store length of _recipients
+            // LCFR - dont cache. storing the length outside the loop costs more gas in assembly usually.
+            let sz := _amounts.length
+
+            // LCFR - reformat the loop structure to be more effecient:
+            // initialize i outside of the pre loop declaration.
+
+            // break if i == array length
+            for {
+                let i := 0
+            } lt(i, sz) {
+                // increment i
+                i := add(i, 1)
+            } {
+                // store offset for _amounts[i]
+                // LCFR - use shl instead of mul
+                let offset := mul(i, 0x20)
+
+                // store _amounts[i]
+                // LCFR - (bug) if _amounts[] is longer than _recipients[] then this will send ETH to the null address
+                let amt := calldataload(add(_amounts.offset, offset))
+
+                // store _recipients[i]
+                // LCFR - (bug) if _recipients[] is shorter than _amounts[] then this will send ETH to a NULL address
+                let recp := calldataload(add(_recipients.offset, offset))
+
+                // send _amounts[i] to _recipients[i]
+                let success := call(
+                    gas(),
+                    recp, // address
+                    amt, // amount
+                    0,
+                    0,
+                    0,
+                    0
+                )
+                // revert if call fails
+                if iszero(success) {
+                    // LCFR - bubble up the revert reason and return instead
+                    revert(0, 0)
+                }
+
+                // LCFR - remove this from the loop and check if balance > 0 at the end of execution 
+                // add _amounts[i] to runningTotal
+                runningTotal := add(runningTotal, amt)
+            }
+            // LCFR - check if contract balance is > 0 something went wrong instead as mentioned above. 
+            // revert if runningTotal != msg.value
+            if iszero(eq(runningTotal, callvalue())) {
+                revert(0, 0)
+            }
+        }
+    }
+
+    function airdropETHLCFR(
+        address[] calldata _recipients,
+        uint256[] calldata _amounts
+    ) external payable {
+        // looop through _recipients
+        assembly {
+
+            // LCFR - fix for array length bug. 
+            if iszero(eq(_recipients.length, _amounts.length)) {
+                mstore(0x00, 0x543bf3c4)
+                revert(0x1c, 0x04)
+            }
+
+            let i := 0
+            for {} 1 { i:= add(i, 1) } {
+                if eq(i, _recipients.length){ break }
+
+                let offset := shl(5, i)
+
+                // store _amounts[i]
+                let amt := calldataload(add(_amounts.offset, offset))
+
+                // store _recipients[i]
+                let recp := calldataload(add(_recipients.offset, offset))
+
+                // send _amounts[i] to _recipients[i]
+                let success := call(
+                    gas(),
+                    recp, // address
+                    amt, // amount
+                    0,
+                    0,
+                    0,
+                    0
+                )
+                // revert if call fails
+                if iszero(success) {
+                    returndatacopy(0x00, 0x00, returndatasize())
+                    revert(0, 0)
+                }
+            }
+
+            if gt(selfbalance(), 0) {
+                mstore(0x00, 0x8689d991)
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    function airdropERC20LCFR(
+        address _token,
+        address[] calldata _recipients,
+        uint256[] calldata _amounts, 
+        uint256 _total
+    ) external {
+        assembly {
+            if iszero(eq(_recipients.length, _amounts.length)) {
+                mstore(0x00, 0x543bf3c4)
+                revert(0x1c, 0x04)
+            }
+
+            // store the transferFrom selector at 0x00
+            mstore(0x00, 0x23b872ddac1db17cac1db17cac1db17cac1db17cac1db17cac1db17cac1db17c)
+            // store the caller as the first parameter to transferFrom()
+            mstore(0x04, caller())
+            // store the contract address as the second parameter to transferFrom()
+            mstore(0x24, address())
+            // store the total amount to transfer as the third parameter to transferFrom()
+            mstore(0x44, _total)
+
+            let successTransferFrom := call(
+                gas(),
+                _token,
+                0,
+                0,
+                0x64,
+                0,
+                0
+            )
+
+            // revert if call fails
+            if iszero(successTransferFrom) {
+                revert(0, 0)
+            }
+
+            // store the transfer selector at 0x00
+            let transfer := 0xa9059cbbac1db17cac1db17cac1db17cac1db17cac1db17cac1db17cac1db17c
+            mstore(0x00, transfer)
+            // store the recipient as the first parameter to transfer()
+            let i := 0
+            for {} 1 { i:= add(i, 1) } {
+                if eq(i, _recipients.length){ break }
+
+                // store offset for _amounts[i]
+                // let offset := mul(i, 0x20)
+                let offset := shl(5, i)
+
+                calldatacopy(0x04, add(_recipients.offset, offset), 0x20)
+
+                calldatacopy(0x24, add(_amounts.offset, offset), 0x20)
+
+                let successTransfer := call(
+                    gas(),
+                    _token,
+                    0,
+                    0,
+                    0x44,
+                    0,
+                    0
+                )
+
                 // revert if call fails
                 if iszero(successTransfer) {
                     revert(0, 0)

--- a/contracts/src/AirdropComparison.sol
+++ b/contracts/src/AirdropComparison.sol
@@ -19,7 +19,10 @@ contract AirdropComparison {
     | disperseToken                                                  | 38802181        | 38802181 | 38802181 | 38802181 | 1       |
     */
 
-    error EthNotSent(); // 0x8689d991
+    // 0x8689d991
+    error EthNotSent(); 
+    // 0x543bf3c4 
+    error arrayLengthMismatch();
 
     /**
      *

--- a/contracts/test/Airdrop.t.sol
+++ b/contracts/test/Airdrop.t.sol
@@ -54,7 +54,7 @@ contract AirdropTest is Test {
         vm.prank(admin);
         token.approve(address(airdrop), AIRDROP_SIZE);
         vm.prank(admin);
-        airdrop.airdropERC20(token, recipients, amounts, AIRDROP_SIZE);
+        airdrop.airdropERC20(address(token), recipients, amounts, AIRDROP_SIZE);
     }
 
     function testAirdrop_airdropETH() external {

--- a/contracts/test/AirdropBug.t.sol
+++ b/contracts/test/AirdropBug.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.17;
+
+import 'forge-std/Test.sol';
+import '../src/AirdropComparison.sol';
+import '../src/Token.sol';
+
+/*
+    Test for demonstrating mismatched array lengths sending ETH or Tokens to Null address.
+    Can be seen using -vvvv and inspecting the calls // using an assertion to check 0 address
+    balance before & after the call.
+
+    │   ├─ [0] 0xa5c3658bf1ea53BBD3EDcDE54E16205E18b45792::fallback{value: 1}() 
+    │   │   └─ ← ()
+    │   ├─ [0] 0xa5c3658bf1ea53BBD3EDcDE54E16205E18b45792::fallback{value: 1}() 
+    │   │   └─ ← ()
+    │   ├─ [0] 0x0000000000000000000000000000000000000000::fallback{value: 1}() 
+    │   │   └─ ← ()
+
+
+*/
+
+contract AirdropBug is Test {
+
+    uint256 constant AIRDROP_SIZE = 9000;
+    AirdropComparison airdrop;
+    Token token;
+    address admin;
+    address[] recipients;
+    uint256[] amounts;
+
+    constructor() {
+        airdrop = new AirdropComparison();
+        // token = new Token();
+        admin = _randomAddress();
+        // token.mint(admin, _initial_supply);
+    }
+    function _randomAddress() private view returns (address payable) {
+        return payable(address(uint160(_randomUint256())));
+    }
+
+    function _randomUint256() private view returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty, block.number)));
+    }
+    
+    function testFailWenTokensAirdropETHArrayLengths() public {
+        vm.prank(admin);
+        vm.deal(admin, 100000 ether);
+
+        recipients = new address[](AIRDROP_SIZE);
+        amounts = new uint256[](AIRDROP_SIZE);
+
+        for (uint256 i = 0; i < AIRDROP_SIZE - 1; i++) {
+            recipients[i] = _randomAddress();
+        }
+
+        for (uint256 i = 0; i < AIRDROP_SIZE; i++) {
+            amounts[i] = 1;
+        }
+        // will try and send ETH to this address on uniningitalized array element
+        uint256 balanceBefore = address(0x0000000000000000000000000000000000000000).balance;
+        airdrop.airdropETH{value: AIRDROP_SIZE}(recipients, amounts);
+        uint256 balanceAfter = address(0x0000000000000000000000000000000000000000).balance;
+
+        assert(balanceAfter <= balanceBefore);
+    }
+
+
+}

--- a/contracts/test/AirdropComparison.t.sol
+++ b/contracts/test/AirdropComparison.t.sol
@@ -46,6 +46,33 @@ contract AirdropComparisonTest is Test {
     airdrop.airdropERC20(token, recipients, amounts, AIRDROP_SIZE);
   }
 
+  function testAirdrop_comparisonAirdropERC20LCFR() external {
+    console.log('[TEST]: LCFRMOD - Airdrops ERC20 tokens to recipients using assembly function');
+    vm.prank(admin);
+    token.approve(address(airdrop), AIRDROP_SIZE);
+    vm.prank(admin);
+    airdrop.airdropERC20LCFR(address(token), recipients, amounts, AIRDROP_SIZE);
+  }
+
+  function testAirdrop_airdropETH() external {
+    console.log(
+      "[TEST]: Airdrops ETH to recipients using assembly function"
+    );
+    payable(admin).transfer(AIRDROP_SIZE);
+    vm.prank(admin);
+    airdrop.airdropETH{value: AIRDROP_SIZE}(recipients, amounts);
+  }
+
+  function testAirdrop_airdropETHLCFR() external {
+    console.log(
+      "[TEST]: LCFRMOD Airdrops ETH to recipients using assembly function"
+    );
+    payable(admin).transfer(AIRDROP_SIZE);
+    vm.prank(admin);
+    airdrop.airdropETHLCFR{value: AIRDROP_SIZE}(recipients, amounts);
+  }
+
+
   function testAirdrop_comparisonDisperseApp() external {
     console.log('[TEST]: Airdrops ERC20 tokens to recipients using disperseApp function for benchmark');
     vm.prank(admin);


### PR DESCRIPTION
Hi 

This git commit has a better log of the changes:

https://github.com/lcfr-eth/wentokens/commit/a5c60b763ecf93f558ee759b3530034cd3f05bc9

Removed safeERC20. Was only used for IERC and the interface isn't used for the calls only addresses used in assembly blocks.
Additional optimizations revolving around removing the usage of freememptr and unnecessary add() calls.

Fixed an array length mismatch bug that could send ETH or ERC20s to the 0x00 address you were maybe aware of. 

The changes results in an additional 54k gas saved on airdropERC20 and an additional 135k for airdropETH using the comparison test contract.

The numbers are from reusing the provided tests and not the exact EVM level savings.

But for example 135k gas from airdropETH would be $11.56-ish with a baseFee of 45 gwei and $5 for airdropERC20.